### PR TITLE
Update casbin to v1.1.0.

### DIFF
--- a/actix-fileadapter-rbac/Cargo.toml
+++ b/actix-fileadapter-rbac/Cargo.toml
@@ -8,6 +8,6 @@ workspace = ".."
 [dependencies]
 actix-web = "2.0"
 actix-rt = "1.1"
-casbin = "0.9"
+casbin = "1.1"
 dotenv = "0.15"
 loge = {version = "0.4", default-features = false, features = ["colored", "chrono"]}

--- a/actix-pgsql-simple/Cargo.toml
+++ b/actix-pgsql-simple/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2018"
 
 [dependencies]
-casbin = "0.9"
+casbin = "1.1"
 diesel-adapter = { version = "0.7", features = ["postgres"] }
 async-std = { version = "1.6", features = ["attributes"] }
 

--- a/actix-pgsql-simple/src/main.rs
+++ b/actix-pgsql-simple/src/main.rs
@@ -51,7 +51,7 @@ async fn index(me: web::Query<Visitor>) -> impl Responder {
 async fn grant(sub: &str, obj: &str, act: &str) -> Result<()> {
     let e = get_enforcer().await;
 
-    if let Ok(authorized) = e.enforce(&[sub, obj, act]).await {
+    if let Ok(authorized) = e.enforce(&[sub, obj, act]) {
         if authorized {
             Ok(())
         } else {

--- a/ntex-fileadapter-acl/Cargo.toml
+++ b/ntex-fileadapter-acl/Cargo.toml
@@ -7,6 +7,6 @@ workspace = ".."
 
 [dependencies]
 ntex = "0.1"
-casbin = "0.9"
+casbin = "1.1"
 dotenv = "0.15"
 loge = {version = "0.4", default-features = false, features = ["colored", "chrono"]}

--- a/ntex-fileadapter-acl/src/main.rs
+++ b/ntex-fileadapter-acl/src/main.rs
@@ -14,7 +14,7 @@ async fn auth(
     let name = req.match_info().get("name").unwrap_or("cat");
     let action = req.match_info().get("action").unwrap_or("meow");
 
-    if let Ok(authorized) = e.enforce(&[name, "data", action]).await {
+    if let Ok(authorized) = e.enforce(&[name, "data", action]) {
         if authorized {
             HttpResponse::Ok().body(format!("{} can {} data", &name, &action))
         } else {


### PR DESCRIPTION
Fixed errors like this

```
   |
17 |     if let Ok(authorized) = e.enforce(&[name, "data", action]).await {
   |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::future::Future` is not implemented for `std::result::Result<bool, casbin::error::Error>`
```

Just remove `.await`. Everything else is normal.

Close #21 